### PR TITLE
[Obsolete Function] Application.LoadLevel Changed

### DIFF
--- a/Assets/Scripts/LevelManager.cs
+++ b/Assets/Scripts/LevelManager.cs
@@ -1,11 +1,12 @@
 ﻿using UnityEngine;
 using System.Collections;
+using UnityEngine.SceneManagement;
 
 public class LevelManager : MonoBehaviour {
 
 	public void LoadLevel(string name){
 		Debug.Log ("New Level load: " + name);
-		Application.LoadLevel (name);
+		SceneManager.LoadScene (name);
 	}
 
 	public void QuitRequest(){


### PR DESCRIPTION
Since Application.LoadLevel is obsolete in Unity 5+, I went ahead and updated it to SceneManager.LoadScene here and in the NumberWizard.cs.

Of course, also added UnityEngine.SceneManagement at the start.